### PR TITLE
Add intersection observer as the default for lazy loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ class GracefulImage extends Component {
     /*
     Attempts to download an image, and tracks its success / failure
   */
-    loadImage (src) {
+    loadImage = () => {
         const image = new Image()
 
         image.onload = () => {
@@ -90,7 +90,7 @@ class GracefulImage extends Component {
         image.onerror = () => {
             this.handleImageRetries(image)
         }
-        image.src = src
+        image.src = this.props.src
     }
 
   /*
@@ -119,10 +119,11 @@ class GracefulImage extends Component {
               this.loadImage()
           } else {
               if ('IntersectionObserver' in window) {
-                  registerObserver(this.imageRef, () => this.loadImage(this.props.src))
+                  registerObserver(this.imageRef, this.loadImage)
               } else {
                   registerListener('load', this.throttledFunction)
                   registerListener('scroll', this.throttledFunction)
+                  registerListener('wheel', this.throttledFunction)
                   registerListener('resize', this.throttledFunction)
                   registerListener('gestureend', this.throttledFunction) // to detect pinch on mobile devices
               }
@@ -136,6 +137,7 @@ class GracefulImage extends Component {
       this.throttledFunction.cancel()
       window.removeEventListener('load', this.throttledFunction)
       window.removeEventListener('scroll', this.throttledFunction)
+      window.removeEventListener('wheel', this.throttledFunction)
       window.removeEventListener('resize', this.throttledFunction)
       window.removeEventListener('gestureend', this.throttledFunction)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,16 @@
 import React, { Component } from 'react'
 import throttle from 'lodash.throttle'
 
-let observer = null
-
 const registerObserver = (el, callback) => {
-    if (!observer) {
-        observer = new IntersectionObserver(
-            (entries, observer) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        callback()
-                        observer.unobserve(el)
-                    }
-                })
+    const observer = new IntersectionObserver(
+        (entries, observer) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    callback()
+                    observer.unobserve(el)
+                }
             })
-    }
+        })
     observer.observe(el)
 }
 
@@ -85,7 +81,7 @@ class GracefulImage extends Component {
     /*
     Attempts to download an image, and tracks its success / failure
   */
-    loadImage = () => {
+    loadImage (src) {
         const image = new Image()
 
         image.onload = () => {
@@ -94,7 +90,7 @@ class GracefulImage extends Component {
         image.onerror = () => {
             this.handleImageRetries(image)
         }
-        image.src = this.props.src
+        image.src = src
     }
 
   /*
@@ -123,7 +119,7 @@ class GracefulImage extends Component {
               this.loadImage()
           } else {
               if ('IntersectionObserver' in window) {
-                  registerObserver(this.imageRef, this.loadImage)
+                  registerObserver(this.imageRef, () => this.loadImage(this.props.src))
               } else {
                   registerListener('load', this.throttledFunction)
                   registerListener('scroll', this.throttledFunction)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -194,4 +194,21 @@ describe('react-graceful-image client', () => {
         const mountWrapper = mount(<GracefulImage { ...props } />)
         mountWrapper.setState({ loaded: false })
     })
+
+    it('should register IntersectionObserver when supported', () => {
+        window.IntersectionObserver = jest.fn(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn()
+        }))
+        const props = {
+            src: 'fake.png',
+            width: '150',
+            height: '150'
+        }
+        shallow(<GracefulImage { ...props } />)
+
+        expect(window.IntersectionObserver).toHaveBeenCalled()
+        expect(window.IntersectionObserver).toHaveBeenCalledTimes(1)
+        window.IntersectionObserver.mockClear()
+    })
 })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -133,11 +133,12 @@ describe('react-graceful-image client', () => {
         shallow(<GracefulImage { ...props } />)
 
         expect(spy).toHaveBeenCalled()
-        expect(spy).toHaveBeenCalledTimes(4)
+        expect(spy).toHaveBeenCalledTimes(5)
         expect(spy.mock.calls[0][0]).toEqual('load')
         expect(spy.mock.calls[1][0]).toEqual('scroll')
-        expect(spy.mock.calls[2][0]).toEqual('resize')
-        expect(spy.mock.calls[3][0]).toEqual('gestureend')
+        expect(spy.mock.calls[2][0]).toEqual('wheel')
+        expect(spy.mock.calls[3][0]).toEqual('resize')
+        expect(spy.mock.calls[4][0]).toEqual('gestureend')
         spy.mockClear()
     })
 
@@ -195,7 +196,7 @@ describe('react-graceful-image client', () => {
         mountWrapper.setState({ loaded: false })
     })
 
-    it('should only ever register a single IntersectionObserver when supported', () => {
+    it('should register an IntersectionObserver when supported', () => {
         const observe = jest.fn()
         const unobserve = jest.fn()
         window.IntersectionObserver = jest.fn(() => ({
@@ -208,11 +209,9 @@ describe('react-graceful-image client', () => {
             height: '150'
         }
         shallow(<GracefulImage { ...props } />)
-        shallow(<GracefulImage { ...props } />)
-        shallow(<GracefulImage { ...props } />)
 
         expect(window.IntersectionObserver).toHaveBeenCalledTimes(1)
-        expect(observe).toHaveBeenCalledTimes(3)
+        expect(observe).toHaveBeenCalledTimes(1)
         window.IntersectionObserver.mockClear()
     })
 })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -195,10 +195,12 @@ describe('react-graceful-image client', () => {
         mountWrapper.setState({ loaded: false })
     })
 
-    it('should register IntersectionObserver when supported', () => {
+    it('should only ever register a single IntersectionObserver when supported', () => {
+        const observe = jest.fn()
+        const unobserve = jest.fn()
         window.IntersectionObserver = jest.fn(() => ({
-            observe: jest.fn(),
-            unobserve: jest.fn()
+            observe,
+            unobserve
         }))
         const props = {
             src: 'fake.png',
@@ -206,9 +208,11 @@ describe('react-graceful-image client', () => {
             height: '150'
         }
         shallow(<GracefulImage { ...props } />)
+        shallow(<GracefulImage { ...props } />)
+        shallow(<GracefulImage { ...props } />)
 
-        expect(window.IntersectionObserver).toHaveBeenCalled()
         expect(window.IntersectionObserver).toHaveBeenCalledTimes(1)
+        expect(observe).toHaveBeenCalledTimes(3)
         window.IntersectionObserver.mockClear()
     })
 })

--- a/tests/ssr.test.js
+++ b/tests/ssr.test.js
@@ -15,6 +15,6 @@ describe('react-graceful-image SSR', () => {
             width: '150',
             height: '150'
         }
-        render(<GracefulImage {...props} />)
+        render(<GracefulImage { ...props } />)
     })
 })


### PR DESCRIPTION
Improve performance by using intersection observer as the preferable option for lazy loading images turning event listeners  into a fallback.